### PR TITLE
diff() does not create unnecessary arrays

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,6 +45,7 @@
             "Exporter" : "0",
             "JSON::MaybeXS" : "0",
             "List::MoreUtils" : "0",
+            "Test::Deep" : "0",
             "parent" : "0",
             "perl" : "5.008001"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.008001';
 requires 'JSON::MaybeXS';
 requires 'List::MoreUtils';
 requires 'Exporter';
+requires 'Test::Deep';
 requires 'parent';
 
 on test => sub {

--- a/lib/JSON/MergePatch.pm
+++ b/lib/JSON/MergePatch.pm
@@ -8,6 +8,7 @@ our $VERSION = "0.03";
 use parent 'Exporter';
 use JSON::MaybeXS qw/encode_json decode_json/;
 use List::MoreUtils qw/uniq/;
+use Test::Deep::NoTest;
 
 our @EXPORT = qw/json_merge_patch json_merge_diff/;
 
@@ -70,7 +71,8 @@ sub diff {
                 if (
                     (!defined $decoded_target->{$key} && !defined $decoded_source->{$key}) ||
                     (defined $decoded_target->{$key} && defined $decoded_source->{$key} && $decoded_target->{$key} eq $decoded_source->{$key}) ||
-                    (defined $decoded_target->{$key} && defined $decoded_source->{$key} && ref $decoded_source->{$key} eq 'HASH' && !%{$decoded_source->{$key}} && ref $decoded_target->{$key} eq 'HASH')
+                    (defined $decoded_target->{$key} && defined $decoded_source->{$key} && ref $decoded_source->{$key} eq 'HASH' && !%{$decoded_source->{$key}} && ref $decoded_target->{$key} eq 'HASH') ||
+                    (defined $decoded_target->{$key} && defined $decoded_source->{$key} && ref $decoded_source->{$key} eq 'ARRAY' && eq_deeply($decoded_target->{$key}, $decoded_source->{$key}))
                 ) {
                     delete $decoded_source->{$key};
                 }

--- a/t/02_diff.t
+++ b/t/02_diff.t
@@ -27,6 +27,7 @@ my $test_cases = +[
     +{ source => '{"a":{},"c":"e"}',         target => '{"a":{"b":"c"},"c":"d"}', expected => {'a'=>{'b'=>undef},'c'=>'e'} },
     +{ source => '{"a":{"a":"a"},"c":"e"}',  target => '{"a":"b","c":"d"}',       expected => {'a'=>{'a'=>'a'},'c'=>'e'} },
     +{ source => '{"a":{"b":"b"},"c":"e"}',  target => '{"a":{"c":"c"},"c":"d"}', expected => {'a'=>{'b'=>'b','c'=>undef},'c'=>'e'} },
+    +{ source => '{"a":"c","arr":[1]}',      target => '{"a":"b","arr":[1]}',     expected => {'a'=>'c'} },
 ];
 
 for my $test_case (@$test_cases) {


### PR DESCRIPTION
I did git rebase of the https://github.com/sojiro14/JSON-MergePatch/pull/4

But I'm still not sure that adding new dependency "Test::Deep" is the best way of solving the problem. Maybe it is better to use something else t recursively check for equality.
